### PR TITLE
Add auth details fetching

### DIFF
--- a/bearer/auth_details.py
+++ b/bearer/auth_details.py
@@ -1,0 +1,53 @@
+from datetime import datetime, timezone
+from enum import Enum
+
+def fromtimestamp_utc(timestamp):
+    return datetime.fromtimestamp(timestamp, timezone.utc)
+
+class OAuth1SignatureMethod(Enum):
+    HMAC_SHA1 = 'HMAC-SHA1'
+    RSA_SHA1 = 'RSA-SHA1'
+    PLAIN_TEXT = 'PLAINTEXT'
+
+class TokenType(Enum):
+    OAUTH1 = 'oauth'
+    OAUTH2_ACCESS_TOKEN = 'bearer'
+    OAUTH2_REFRESH_TOKEN = 'refresh' # Not defined in RFC7662
+    OPENID_CONNECT = 'id' # Not defined in RFC7662
+
+class TokenResponse:
+  def __init__(self, body: any, headers: dict):
+      self.body = body
+      self.headers = headers
+
+class TokenData:
+    def __init__(self, raw_data: dict):
+        token_type = TokenType(raw_data['token_type'])
+        expect_scopes = token_type in [
+          TokenType.OAUTH2_ACCESS_TOKEN,
+          TokenType.OAUTH2_REFRESH_TOKEN
+        ]
+
+        self.is_active = raw_data['active']
+        self.client_id = raw_data['client_id']
+        self.expires_at = fromtimestamp_utc(raw_data['exp']) if 'exp' in raw_data else None
+        self.issued_at = fromtimestamp_utc(raw_data['iat'])
+        self.scopes = raw_data['scope'].split(' ') if 'scope' in raw_data else ([] if expect_scopes else None)
+        self.token_type = token_type
+        self.value = raw_data['value']
+
+class AuthDetails:
+    def __init__(self, raw_data: dict):
+        self.access_token = TokenData(raw_data['accessToken'])
+        self.callback_params = raw_data['callbackParams']
+        self.client_id = raw_data.get('clientID')
+        self.client_secret = raw_data.get('clientSecret')
+        self.consumer_key = raw_data.get('consumerKey')
+        self.consumer_secret = raw_data.get('consumerSecret')
+        self.id_token =  TokenData(raw_data['idToken']) if 'idToken' in raw_data else None
+        self.id_token_jwt = raw_data.get('idTokenJwt')
+        self.raw_data = raw_data
+        self.refresh_token = TokenData(raw_data['refreshToken']) if 'refreshToken' in raw_data else None
+        self.token_response = TokenResponse(raw_data['tokenResponse']['body'], raw_data['tokenResponse']['headers'])
+        self.token_secret = raw_data.get('tokenSecret')
+        self.signature_method = OAuth1SignatureMethod(raw_data['signatureMethod']) if 'signatureMethod' in raw_data else None

--- a/bearer/errors.py
+++ b/bearer/errors.py
@@ -1,0 +1,3 @@
+class MissingAuthId(Exception):
+    def __init__(self):
+        super().__init__('No Auth ID has been set. Please call `auth`')

--- a/tests/test_auth_details.py
+++ b/tests/test_auth_details.py
@@ -1,0 +1,156 @@
+from datetime import datetime, timezone
+
+from bearer.auth_details import AuthDetails, OAuth1SignatureMethod, TokenType
+
+ACCESS_TOKEN = 'test-access-token'
+REFRESH_TOKEN = 'test-refresh-token'
+ID_TOKEN = 'test-id-token'
+ID_TOKEN_JWT = { 'some': 'id-data' }
+RESPONSE_BODY = { 'body': 'data' }
+RESPONSE_HEADERS = { 'Content-Type': 'application/json' }
+CONSUMER_KEY = 'test-consumer-key'
+CONSUMER_SECRET = 'test-secret'
+TOKEN_SECRET = 'test-token-secret'
+CLIENT_ID = 'test-client-id'
+CLIENT_SECRET = 'test-client-secret'
+
+CALLBACK_PARAMS = {
+    'oauth_token': 'test-token',
+    'oauth_verifier': 'test-verifier'
+}
+
+TOKEN_RESPONSE = {
+    'body': RESPONSE_BODY,
+    'headers': RESPONSE_HEADERS
+}
+
+OAUTH1_RAW_DATA = {
+    'accessToken': {
+        'active': True,
+        'value': ACCESS_TOKEN,
+        'client_id': CONSUMER_KEY,
+        'iat': 1574087265,
+        'token_type': 'oauth'
+    },
+    'callbackParams': CALLBACK_PARAMS,
+    'consumerKey': CONSUMER_KEY,
+    'consumerSecret': CONSUMER_SECRET,
+    'signatureMethod': 'HMAC-SHA1',
+    'tokenResponse': TOKEN_RESPONSE,
+    'tokenSecret': TOKEN_SECRET
+}
+
+OAUTH2_MINIMAL_RAW_DATA = {
+    'accessToken': {
+        'active': True,
+        'value': ACCESS_TOKEN,
+        'client_id': CLIENT_ID,
+        'iat': 1573661439,
+        'token_type': 'bearer'
+    },
+    'callbackParams': CALLBACK_PARAMS,
+    'clientID': CLIENT_ID,
+    'clientSecret': CLIENT_SECRET,
+    'tokenResponse': TOKEN_RESPONSE
+}
+
+OAUTH2_FULL_RAW_DATA = {
+    **OAUTH2_MINIMAL_RAW_DATA,
+    'accessToken': {
+        **OAUTH2_MINIMAL_RAW_DATA['accessToken'],
+        'active': False,
+        'exp': 1573665039,
+        'scope': 'read write'
+    },
+    'idToken': {
+        'active': True,
+        'value': ID_TOKEN,
+        'client_id': CLIENT_ID,
+        'iat': 1573661439,
+        'token_type': 'id'
+    },
+    'idTokenJwt': ID_TOKEN_JWT,
+    'refreshToken': {
+        'active': True,
+        'value': REFRESH_TOKEN,
+        'client_id': CLIENT_ID,
+        'iat': 1573661439,
+        'scope': 'read write',
+        'token_type': 'refresh'
+    }
+}
+
+def test_oauth1():
+    auth_details = AuthDetails(OAUTH1_RAW_DATA)
+
+    assert auth_details.raw_data == OAUTH1_RAW_DATA
+    assert auth_details.callback_params == CALLBACK_PARAMS
+    assert auth_details.consumer_key == CONSUMER_KEY
+    assert auth_details.consumer_secret == CONSUMER_SECRET
+    assert auth_details.signature_method == OAuth1SignatureMethod.HMAC_SHA1
+    assert auth_details.token_response.body == RESPONSE_BODY
+    assert auth_details.token_response.headers == RESPONSE_HEADERS
+    assert auth_details.token_secret == TOKEN_SECRET
+
+    access_token = auth_details.access_token
+
+    assert access_token.is_active
+    assert access_token.client_id == CONSUMER_KEY
+    assert access_token.expires_at is None
+    assert access_token.issued_at == datetime(2019, 11, 18, 14, 27, 45, tzinfo=timezone.utc)
+    assert access_token.token_type == TokenType.OAUTH1
+    assert access_token.value == ACCESS_TOKEN
+
+
+def test_oauth2_minimal():
+    auth_details = AuthDetails(OAUTH2_MINIMAL_RAW_DATA)
+
+    assert auth_details.raw_data == OAUTH2_MINIMAL_RAW_DATA
+    assert auth_details.callback_params == CALLBACK_PARAMS
+    assert auth_details.client_id == CLIENT_ID
+    assert auth_details.client_secret == CLIENT_SECRET
+    assert auth_details.id_token is None
+    assert auth_details.id_token_jwt is None
+    assert auth_details.refresh_token is None
+    assert auth_details.token_response.body == RESPONSE_BODY
+    assert auth_details.token_response.headers == RESPONSE_HEADERS
+
+    access_token = auth_details.access_token
+
+    assert access_token.is_active
+    assert access_token.client_id == CLIENT_ID
+    assert access_token.expires_at is None
+    assert access_token.issued_at == datetime(2019, 11, 13, 16, 10, 39, tzinfo=timezone.utc)
+    assert access_token.scopes == []
+    assert access_token.token_type == TokenType.OAUTH2_ACCESS_TOKEN
+    assert access_token.value == ACCESS_TOKEN
+
+
+def test_oauth2_full():
+    auth_details = AuthDetails(OAUTH2_FULL_RAW_DATA)
+
+    assert auth_details.raw_data == OAUTH2_FULL_RAW_DATA
+    assert auth_details.id_token_jwt == ID_TOKEN_JWT
+
+    access_token = auth_details.access_token
+
+    assert not access_token.is_active
+    assert access_token.expires_at == datetime(2019, 11, 13, 17, 10, 39, tzinfo=timezone.utc)
+    assert access_token.issued_at == datetime(2019, 11, 13, 16, 10, 39, tzinfo=timezone.utc)
+    assert access_token.scopes == ['read', 'write']
+
+    refresh_token = auth_details.refresh_token
+    assert refresh_token.client_id == CLIENT_ID
+    assert refresh_token.expires_at is None
+    assert refresh_token.issued_at == datetime(2019, 11, 13, 16, 10, 39, tzinfo=timezone.utc)
+    assert refresh_token.scopes == ['read', 'write']
+    assert refresh_token.token_type == TokenType.OAUTH2_REFRESH_TOKEN
+    assert refresh_token.value == REFRESH_TOKEN
+
+    id_token = auth_details.id_token
+    assert id_token.client_id == CLIENT_ID
+    assert id_token.expires_at is None
+    assert id_token.issued_at == datetime(2019, 11, 13, 16, 10, 39, tzinfo=timezone.utc)
+    assert id_token.scopes is None
+    assert id_token.token_type == TokenType.OPENID_CONNECT
+    assert id_token.value == ID_TOKEN

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -22,8 +22,8 @@ ENDPOINT_URL = '{}test?query=param'.format(URL)
 
 HEADERS = {'test': 'header'}
 SENT_HEADERS = {
-    'Bearer-Proxy-test': 'header',
-    'Bearer-Request-Id': 'bearer-request-id'
+    'Authorization': API_KEY,
+    'test': 'header'
 }
 QUERY = {'query': 'param'}
 BODY = {'body': 'data'}
@@ -32,7 +32,9 @@ VERSION = pkg_resources.require("bearer")[0].version
 
 
 def test_request_supports_get(requests_mock):
-    requests_mock.get(ENDPOINT_URL, headers=SENT_HEADERS, json=SUCCESS_PAYLOAD)
+    requests_mock.get(ENDPOINT_URL,
+                      request_headers=SENT_HEADERS,
+                      json=SUCCESS_PAYLOAD)
 
     client = Bearer(API_KEY)
     integration = client.integration(BUID)
@@ -42,7 +44,7 @@ def test_request_supports_get(requests_mock):
 
 
 def test_request_supports_head(requests_mock):
-    requests_mock.head(ENDPOINT_URL, headers=SENT_HEADERS)
+    requests_mock.head(ENDPOINT_URL, request_headers=SENT_HEADERS)
 
     client = Bearer(API_KEY)
     integration = client.integration(BUID)
@@ -53,7 +55,7 @@ def test_request_supports_head(requests_mock):
 
 def test_request_supports_post(requests_mock):
     requests_mock.post(ENDPOINT_URL,
-                       headers=SENT_HEADERS,
+                       request_headers=SENT_HEADERS,
                        json=SUCCESS_PAYLOAD)
 
     client = Bearer(API_KEY)
@@ -68,7 +70,9 @@ def test_request_supports_post(requests_mock):
 
 
 def test_request_supports_put(requests_mock):
-    requests_mock.put(ENDPOINT_URL, headers=SENT_HEADERS, json=SUCCESS_PAYLOAD)
+    requests_mock.put(ENDPOINT_URL,
+                      request_headers=SENT_HEADERS,
+                      json=SUCCESS_PAYLOAD)
 
     client = Bearer(API_KEY)
     integration = client.integration(BUID)
@@ -83,7 +87,7 @@ def test_request_supports_put(requests_mock):
 
 def test_request_supports_patch(requests_mock):
     requests_mock.patch(ENDPOINT_URL,
-                        headers=SENT_HEADERS,
+                        request_headers=SENT_HEADERS,
                         json=SUCCESS_PAYLOAD)
 
     client = Bearer(API_KEY)
@@ -99,7 +103,7 @@ def test_request_supports_patch(requests_mock):
 
 def test_request_supports_delete(requests_mock):
     requests_mock.delete(ENDPOINT_URL,
-                         headers=SENT_HEADERS,
+                         request_headers=SENT_HEADERS,
                          json=SUCCESS_PAYLOAD)
 
     client = Bearer(API_KEY)
@@ -117,7 +121,7 @@ def test_request_passes_auth_id(requests_mock):
     auth_id = 'test-auth-id'
     expected_headers = {**SENT_HEADERS, 'Bearer-Auth-Id': auth_id}
     requests_mock.post(ENDPOINT_URL,
-                       headers=expected_headers,
+                       request_headers=expected_headers,
                        json=SUCCESS_PAYLOAD)
 
     client = Bearer(API_KEY)
@@ -135,7 +139,7 @@ def test_request_passes_setup_id(requests_mock):
     setup_id = 'test-setup-id'
     expected_headers = {**SENT_HEADERS, 'Bearer-Setup-Id': setup_id}
     requests_mock.post(ENDPOINT_URL,
-                       headers=expected_headers,
+                       request_headers=expected_headers,
                        json=SUCCESS_PAYLOAD)
 
     client = Bearer(API_KEY)


### PR DESCRIPTION
Adds `get_auth` method to allow fetching auth details in a user-friendly way.

Also fixes tests that were using the wrong keyword arg name for asserting request headers.